### PR TITLE
Fix warnings in CI

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -27,6 +27,11 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends hmmer t-coffee
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -89,6 +89,8 @@ jobs:
         uses: docker/metadata-action@v6
         with:
           images: docker.io/${{ steps.vars.outputs.image_repository }}
+          flavor: |
+            latest=false
           tags: |
             type=sha,format=short,prefix=sha-
             type=ref,event=tag


### PR DESCRIPTION
# Fix warning

> Both `hmmer` and `t-coffee` must be installed by apt

```bash
=============================== warnings summary ===============================
../../../../../opt/hostedtoolcache/Python/3.12.13/x64/lib/python3.12/site-packages/b2bTools/singleSeq/PSPer/Constants.py:14
  /opt/hostedtoolcache/Python/3.12.13/x64/lib/python3.12/site-packages/b2bTools/singleSeq/PSPer/Constants.py:14: UserWarning: 
  PSPer can only run if HMMER is installed.
  Please install it from http://hmmer.org on your computer, and refer to this installation in the
     b2bTools/python/b2bTools/singleSeq/PSPer/Constant.py
  file by pointing the `hmmbuild_bin` and `hmmscan_bin` variables at the binaries.
  
    warnings.warn("""

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================== 51 passed, 1 warning in 6.24s =========================
```

